### PR TITLE
Prevent continuous notification triggering on android

### DIFF
--- a/src/android/notification/trigger/MatchTrigger.java
+++ b/src/android/notification/trigger/MatchTrigger.java
@@ -93,6 +93,7 @@ public class MatchTrigger extends IntervalTrigger {
     private Calendar getBaseTriggerDate(Date date) {
         Calendar cal = getCal(date);
 
+        cal.set(Calendar.MILLISECOND, 0);
         cal.set(Calendar.SECOND, 0);
 
         if (matchers.get(0) != null) {
@@ -205,7 +206,11 @@ public class MatchTrigger extends IntervalTrigger {
                     break;
             }
         } else
-        if (cal.get(Calendar.MINUTE) < now.get(Calendar.MINUTE)) {
+        if (
+            (cal.get(Calendar.MINUTE) < now.get(Calendar.MINUTE)) ||
+            (cal.get(Calendar.SECOND) < now.get(Calendar.SECOND)) ||
+            (cal.get(Calendar.MILLISECOND) < now.get(Calendar.MILLISECOND))
+        ) {
             switch (unit) {
                 case MINUTE:
                     addToDate(cal, now, Calendar.MINUTE, 1);


### PR DESCRIPTION
A scheduled notification on android with an infinite trigger of "every" will be continuously
triggered for an entire minute.

This is caused by the immediately rescheduled notification request not considering
any second or millisecond differences between now and the scheduled time.