### PR TITLE
Fix Null Pointer Exception in Manager.java

### DIFF
--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -343,10 +343,13 @@ public final class Manager {
 
         try {
             String json     = prefs.getString(toastId, null);
+            if (json == null) {
+                return null;
+            }
             JSONObject dict = new JSONObject(json);
 
             return new Options(context, dict);
-        } catch (JSONException | NullPointerException e) {
+        } catch (JSONException e) {
             e.printStackTrace();
             return null;
         }


### PR DESCRIPTION
```
java.lang.NullPointerException: 
  at org.json.JSONTokener.nextCleanInternal (JSONTokener.java:121)
  at org.json.JSONTokener.nextValue (JSONTokener.java:98)
  at org.json.JSONObject.<init> (JSONObject.java:164)
  at org.json.JSONObject.<init> (JSONObject.java:181)
  at de.appplant.cordova.plugin.notification.Manager.getOptions (Manager.java:346)
  at de.appplant.cordova.plugin.notification.Manager.get (Manager.java:363)
  at de.appplant.cordova.plugin.notification.Manager.getByIds (Manager.java:255)
  at de.appplant.cordova.plugin.notification.Manager.getAll (Manager.java:269)
  at de.appplant.cordova.plugin.notification.Manager.cancelAll (Manager.java:192)
  at de.appplant.cordova.plugin.localnotification.LocalNotification.cancelAll (LocalNotification.java:324)
  at de.appplant.cordova.plugin.localnotification.LocalNotification.access$700 (LocalNotification.java:60)
  at de.appplant.cordova.plugin.localnotification.LocalNotification$1.run (LocalNotification.java:157)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1167)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:641)
  at java.lang.Thread.run (Thread.java:919)
```